### PR TITLE
Use executable-find to look up the flow executable

### DIFF
--- a/company-flow.el
+++ b/company-flow.el
@@ -115,7 +115,7 @@ PROCESS, and terminates standard input with EOF."
 (defun company-flow--candidates-query (prefix callback)
   (let* ((line (line-number-at-pos (point)))
          (col (+ 1 (current-column)))
-         (command (list company-flow-executable
+         (command (list (executable-find company-flow-executable)
                         "autocomplete"
                         buffer-file-name
                         (number-to-string line)


### PR DESCRIPTION
Flycheck uses executable-find to launch flow.   Make sure that company-flow uses the same binary.

In my case, my `exec-path` included `node_modules/.bin`, so flycheck would launch `node_modules/.bin/flow`, but company-flow would launch `/usr/local/bin/flow`, and they'd end up detecting flow-server conflicts and constantly relaunching the flow server from scratch.   WDYT to this change?
