### PR TITLE
Fix 'not enough type information to autocomplete' errors

### DIFF
--- a/company-flow.el
+++ b/company-flow.el
@@ -87,8 +87,9 @@ registrationSuccess () => {type: 'REGISTRATION_SUCCESS'}"
         (propertize text 'meta meta)))))
 
 (defun company-flow--parse-output (output)
-  (mapcar 'company-flow--make-candidate
-          (split-string output "\n")))
+  (when (not (equal output "Error: not enough type information to autocomplete\n"))
+    (mapcar 'company-flow--make-candidate
+            (split-string output "\n"))))
 
 (defun company-flow--get-output (process)
   "Get the complete output of PROCESS."


### PR DESCRIPTION
I keep sporadically seeing Flow completion errors where the completion command returns a successful status code, but the outputted text is "Error: not enough type information to autocomplete".    It seems easiest to reproduce in a react component - if you have your cursor at `I` - 

```jsx
render() {
  return <MyComponent I
}
```

at which point company suggests `Error:` as an autocompletion token.   How about this fix?