### PR TITLE
Add jsx support

### DIFF
--- a/company-flow.el
+++ b/company-flow.el
@@ -54,7 +54,9 @@
 
 (defcustom company-flow-modes '(
                                 js-mode
+                                js-jsx-mode
                                 js2-mode
+                                js2-jsx-mode
                                 web-mode
                                 )
   "List of major modes where company-flow will be providing completions."


### PR DESCRIPTION
I think default supporting modes also should include jsx-related modes.

JSX is used by react, one of the famous JS framework, and react is developed by same company, fb.

It's enough for defaulting jsx too, at least I think.